### PR TITLE
Feature/more friendly white label section on failure

### DIFF
--- a/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
@@ -120,7 +120,7 @@ function dynamicSection(section: any, index: number) {
               size: "large",
             }}
             image={{
-              src: section.white_paper?.cover_image?.url ?? undefined,
+              src: section.white_paper?.cover_image?.url,
               alt: section.white_paper?.cover_image?.alternativeText ?? "",
             }}
             text={section.white_paper.description}

--- a/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
@@ -114,14 +114,14 @@ function dynamicSection(section: any, index: number) {
           <SectionWhitepaper
             title={section.white_paper.title}
             cta={{
-              text: "Download whitepaper",
-              href: section.white_paper.download_file.url,
+              text: "Download white paper",
+              href: section.white_paper.download_file?.url ?? "",
               variant: "cta",
               size: "large",
             }}
             image={{
-              src: section.white_paper.cover_image.url,
-              alt: section.white_paper.cover_image.alternativeText ?? "",
+              src: section.white_paper?.cover_image?.url ?? undefined,
+              alt: section.white_paper?.cover_image?.alternativeText ?? "",
             }}
             text={section.white_paper.description}
           />

--- a/nextjs/src/components/sections/section-whitepaper.tsx
+++ b/nextjs/src/components/sections/section-whitepaper.tsx
@@ -12,7 +12,7 @@ type SectionWhitepaperProps = {
    */
   text: string
   cta: CTA
-  image: {
+  image?: {
     src: string
     alt: string
   }
@@ -39,9 +39,11 @@ const SectionWhitepaper: React.FC<SectionWhitepaperProps> = ({
           {title}
         </Title>
         <Text markdown={text} />
-        <LinkButton href={cta.href} variant={cta.variant} size={cta.size}>
-          {cta.text}
-        </LinkButton>
+        {cta.href && (
+          <LinkButton href={cta.href} variant={cta.variant} size={cta.size}>
+            {cta.text}
+          </LinkButton>
+        )}
       </div>
     </div>
   )

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -348,8 +348,7 @@ export interface RelationsSectionSolutionsRelation
     displayName: 'Section Solutions Relation';
   };
   attributes: {
-    section_props: Schema.Attribute.Component<'sections.section-props', false> &
-      Schema.Attribute.Required;
+    section_props: Schema.Attribute.Component<'sections.section-props', false>;
     solutions: Schema.Attribute.Component<
       'relations.solutions-relation-with-description',
       true


### PR DESCRIPTION
Make the component more friendly on failure, when no required file or image was attached in the "White Label entity" just hide the image/button but show the text so the frontend does not break aggressively.