### PR TITLE
Feature/aw 54 wider icon cards section

### DIFF
--- a/nextjs/src/app/[locale]/theme/page.tsx
+++ b/nextjs/src/app/[locale]/theme/page.tsx
@@ -24,6 +24,8 @@ import {
   calendlySection,
   youtubeSection,
   services,
+  cardIconGridExample,
+  cardIconWiderExample,
 } from "./texts"
 import Container from "@/components/container"
 import CardSlider from "@/components/cards/card-slider"
@@ -358,6 +360,43 @@ export default function Theme({
             )
           })}
         </CardSlider>
+      </Container>
+
+      <Container
+        id="card-icon-grid"
+        padding="both-padding"
+        background="neutral"
+      >
+        <CardGroup maxWidth="none">
+          {cardIconGridExample.cards.map((item, i) => {
+            return (
+              <CardIcon
+                imageUrl={item.icon.src}
+                title={item.title}
+                description={item.description}
+                cta={item.cta}
+                key={i}
+              />
+            )
+          })}
+        </CardGroup>
+      </Container>
+
+      <Container id="card-icon-grid" padding="both-padding" background="white">
+        <SectionGroup title="Why Adfinis?" align="center">
+          <CardGroup hasDividers columns={3} maxWidth="7xl">
+            {cardIconWiderExample.cards.map((item, i) => {
+              return (
+                <CardIcon
+                  imageUrl={item.icon.src}
+                  title={item.title}
+                  description={item.description}
+                  key={i}
+                />
+              )
+            })}
+          </CardGroup>
+        </SectionGroup>
       </Container>
     </main>
   )

--- a/nextjs/src/app/[locale]/theme/texts.ts
+++ b/nextjs/src/app/[locale]/theme/texts.ts
@@ -247,7 +247,7 @@ export const journeySection = {
     {
       title: "Build",
       description:
-        "We optimally support you in the implementation of your individual infrastructure.",
+        "We optimally support you in the implementation of your individual infrastructure. Extra sentence for more spacial diversity.",
       icon: {
         src: "/svg/icons/icon_build.svg",
         alt: "Build icon",
@@ -615,6 +615,129 @@ export const services = {
   cards,
   ctas,
 }
+
+export const cardIconWiderExample = {
+  title: "## Regulation and Compliance",
+  cards: [
+    {
+      title: "Regulation and Compliance",
+      description:
+        "At Adfinis, we’re first-class expert techies: meaning you’ll never encounter an Adfinis employee who doesn’t know what you’re talking about. This is essential when we’re assessing your needs and it will enable us to only offer what you currently need most.",
+      icon: {
+        src: "/svg/icons/icon_plan.svg",
+        alt: "Plan icon",
+      },
+    },
+    {
+      title: "Multi-Vendor Solutions",
+      description:
+        "We support you in meeting regulatory requirements and achieving compliance with the proper tooling, ensuring your operations adhere to industry standards.",
+      icon: {
+        src: "/svg/icons/icon_build.svg",
+        alt: "Build icon",
+      },
+    },
+    {
+      title: "Workflow Simplification",
+      description:
+        "We support you in meeting regulatory requirements and achieving compliance with the proper tooling, ensuring your operations adhere to industry standards.",
+      icon: {
+        src: "/svg/icons/icon_run.svg",
+        alt: "Run icon",
+      },
+    },
+  ],
+} as const
+
+export const cardIconGridExample = {
+  title: "## Let's Shape Your Journey **Together**",
+  cards: [
+    {
+      title: "Plan",
+      description:
+        "We create a situation analysis and elicit the best possible solution for your current infrastructure.",
+      icon: {
+        src: "/svg/icons/icon_plan.svg",
+        alt: "Plan icon",
+      },
+      cta: {
+        text: "Get your checkup",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+    {
+      title: "Build",
+      description:
+        "We optimally support you in the implementation of your individual infrastructure.",
+      icon: {
+        src: "/svg/icons/icon_build.svg",
+        alt: "Build icon",
+      },
+      cta: {
+        text: "Find your solution",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+    {
+      title: "Run",
+      description:
+        "With our 24/7 SLA, we provide you with all-round support. Benefit from fast and reliable support.",
+      icon: {
+        src: "/svg/icons/icon_run.svg",
+        alt: "Run icon",
+      },
+      cta: {
+        text: "Choose your service",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+    {
+      title: "Create",
+      description:
+        "We create a situation analysis and elicit the best possible solution for your current infrastructure.",
+      icon: {
+        src: "/svg/icons/icon_plan.svg",
+        alt: "Plan icon",
+      },
+      cta: {
+        text: "Get your checkup",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+    {
+      title: "Manage",
+      description:
+        "We optimally support you in the implementation of your individual infrastructure.",
+      icon: {
+        src: "/svg/icons/icon_build.svg",
+        alt: "Build icon",
+      },
+      cta: {
+        text: "Find your solution",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+    {
+      title: "Lead",
+      description:
+        "With our 24/7 SLA, we provide you with all-round support. Benefit from fast and reliable support.",
+      icon: {
+        src: "/svg/icons/icon_run.svg",
+        alt: "Run icon",
+      },
+      cta: {
+        text: "Choose your service",
+        href: "/contact",
+        variant: "secondary",
+      },
+    },
+  ],
+} as const
 
 export const footer = {
   columns: [

--- a/nextjs/src/components/cards/card-group.tsx
+++ b/nextjs/src/components/cards/card-group.tsx
@@ -6,6 +6,10 @@ type CardGroupProps = {
   columns?: 1 | 2 | 3 | 4 | 5 | 6
   children: React.ReactNode
   hasDividers?: boolean
+  /**
+   * @info defaults to`5xl` for backwards compatibility when nothing provided.
+   */
+  maxWidth?: "5xl" | "6xl" | "7xl" | "none"
 }
 
 /**
@@ -15,11 +19,12 @@ const CardGroup: React.FC<CardGroupProps> = ({
   columns = 3,
   children,
   hasDividers,
+  maxWidth = "5xl",
 }) => {
   return (
     <div
       className={clsx([
-        "grid grid-cols-1 gap-12 max-w-5xl mx-auto",
+        "grid grid-cols-1 gap-12 mx-auto",
         hasDividers && "card-group-dividers",
         {
           "lg:grid-cols-1": columns === 1,
@@ -28,6 +33,12 @@ const CardGroup: React.FC<CardGroupProps> = ({
           "lg:grid-cols-4": columns === 4,
           "lg:grid-cols-5": columns === 5,
           "lg:grid-cols-6": columns === 6,
+        },
+        {
+          "max-w-5xl": maxWidth === "5xl",
+          "max-w-6xl": maxWidth === "6xl",
+          "max-w-7xl": maxWidth === "7xl",
+          "max-w-none": maxWidth === "none",
         },
       ])}
     >

--- a/nextjs/src/components/cards/card-icon.tsx
+++ b/nextjs/src/components/cards/card-icon.tsx
@@ -23,7 +23,7 @@ const CardIcon: React.FC<CardIconProps> = ({
   return (
     <div
       data-component="CardIcon"
-      className="bg-white rounded-xl px-6 pt-6 pb-8 shadow-2 grid gap-6 divide-vertical-6 justify-items-center"
+      className="bg-white rounded-xl px-6 pt-6 pb-8 shadow-2 flex flex-col justify-items-center gap-6 content-start"
       data-scheme="light"
     >
       {imageUrl && (
@@ -32,27 +32,22 @@ const CardIcon: React.FC<CardIconProps> = ({
           src={imageUrl}
           width={300}
           height={300}
-          className="h-20 mb-6 mx-auto"
+          className="h-18 mx-auto"
         />
       )}
-      <Title
-        level={3}
-        boldness={"semibold"}
-        align={"center"}
-        className="mb-6 lg:mb-1 lg:min-h-[2lh]"
-      >
+      <Title level={3} boldness={"semibold"} align={"center"}>
         {title}
       </Title>
       <Text
         markdown={description}
-        className="text-center self-start lg:flex-grow mb-6"
+        className="text-center self-start flex-grow"
       />
       {cta && (
         <Link
           href={cta.href}
           variant={"secondary"}
           size={"small"}
-          className="px-4 self-center"
+          className="px-4 self-center place-self-end"
         >
           {cta.text}
         </Link>

--- a/nextjs/src/components/cards/card-service.tsx
+++ b/nextjs/src/components/cards/card-service.tsx
@@ -21,7 +21,7 @@ const CardIcon: React.FC<CardServicesProps> = ({
   usps,
 }) => {
   return (
-    <div className="rounded-xl px-6 pt-6 pb-8 shadow-2 grid gap-6 divide-vertical-6 justify-items-stretch max-w-sm">
+    <div className="rounded-xl px-6 pt-6 pb-8 shadow-2 grid gap-6 justify-items-stretch max-w-sm">
       <Title level={3} boldness={"semibold"} align={"center"}>
         {title}
       </Title>


### PR DESCRIPTION
Wider example but narrower than container (make use of different maxWidth option!)

<img width="1792" alt="Screenshot 2025-01-19 at 17 23 04" src="https://github.com/user-attachments/assets/da26cf4d-f7de-421d-8d55-e7b996e1b3e2" />

Grid example:

<img width="1792" alt="Screenshot 2025-01-19 at 17 23 43" src="https://github.com/user-attachments/assets/0cac25c8-f11c-4914-9ceb-faa3d5e5844f" />
