### PR TITLE
fix: Remove grid gap-8 classNames on all intro sections

### DIFF
--- a/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partners-products.tsx
@@ -42,7 +42,7 @@ export default async function PartnersProducts({
       </NavProvider>
       {intro && (
         <Intro>
-          <Text markdown={intro} className="grid gap-8" />
+          <Text markdown={intro} />
         </Intro>
       )}
       {sections && sections.length > 0 && sections.map(renderSections)}

--- a/nextjs/src/app/[locale]/(solutions-group)/solutions.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/solutions.tsx
@@ -36,7 +36,7 @@ export default async function Solutions({
       </NavProvider>
       {intro && (
         <Intro>
-          <Text markdown={intro} className="grid gap-8" />
+          <Text markdown={intro} />
         </Intro>
       )}
       {sections && sections.length > 0 && sections.map(renderSections)}

--- a/nextjs/src/app/[locale]/(solutions-group)/solutions/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/solutions/[slug]/page.tsx
@@ -46,7 +46,7 @@ export default async function SolutionsDetailPage({
 
       {intro && (
         <Intro>
-          <Text markdown={intro} className="grid gap-8" />
+          <Text markdown={intro} />
         </Intro>
       )}
       {sections && sections.length > 0 && sections.map(renderSections)}

--- a/nextjs/src/app/[locale]/events/page.tsx
+++ b/nextjs/src/app/[locale]/events/page.tsx
@@ -49,7 +49,7 @@ export default async function EventsOverviewPage({
       </NavProvider>
       {intro && (
         <Intro>
-          <Text markdown={intro} className="grid gap-8" />
+          <Text markdown={intro} />
         </Intro>
       )}
       {cards.length > 0 && (

--- a/nextjs/src/app/[locale]/theme/page.tsx
+++ b/nextjs/src/app/[locale]/theme/page.tsx
@@ -79,7 +79,7 @@ export default function Theme({
 
       <Intro>
         <Title markdown={intro.title} align="center" />
-        <Text markdown={intro.text} className="grid gap-8" />
+        <Text markdown={intro.text} />
       </Intro>
 
       <Container id="Solutions" padding="both-padding" background="neutral">

--- a/nextjs/src/app/homepage.tsx
+++ b/nextjs/src/app/homepage.tsx
@@ -36,7 +36,7 @@ export default async function Homepage({
       </NavProvider>
       {intro && (
         <Intro>
-          <Text markdown={intro} className="grid gap-8" />
+          <Text markdown={intro} />
         </Intro>
       )}
       {sections && sections.length > 0 && sections.map(renderSections)}


### PR DESCRIPTION
fixed everywhere where it occurred, not just that one page.