### PR TITLE
feat: Add support for images in TwoColumnSection

### DIFF
--- a/nextjs/src/app/text.css
+++ b/nextjs/src/app/text.css
@@ -108,4 +108,10 @@
             list-style-image: url('/svg/chevron-right-dark.svg');
         }
     }
+
+    .markdown-text-image {
+        img {
+            @apply w-full h-auto;
+        }
+    }
 }

--- a/nextjs/src/components/dynamic-zone/wrapper/sections/two-column-section.tsx
+++ b/nextjs/src/components/dynamic-zone/wrapper/sections/two-column-section.tsx
@@ -1,9 +1,9 @@
 import SectionGroup from "@/components/sections/section-group"
-import Text from "@/components/text"
 import Container from "@/components/container"
 import { SectionProps } from "@/components/dynamic-zone/wrapper/section-props"
 import LinkButton from "@/components/link-button"
 import { CTA } from "@/lib/cta"
+import TextImage from "@/components/text-image"
 
 type Props = {
   props: SectionProps
@@ -19,8 +19,8 @@ export default function TwoColumnSection({ section }: { section: Props }) {
       padding={section.props.padding}
     >
       <SectionGroup columns={2}>
-        <Text markdown={section.left_column} />
-        <Text markdown={section.right_column} />
+        <TextImage markdown={section.left_column} />
+        <TextImage markdown={section.right_column} />
         {section.cta && (
           <LinkButton {...section.cta} className="place-self-start">
             {section.cta.label}

--- a/nextjs/src/components/text-image.tsx
+++ b/nextjs/src/components/text-image.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+interface TextImage {
+  markdown: string
+  className?: string
+}
+
+/**
+ * @description Github-flavored markdown text component with images support.
+ * This is a copy of text.tsx with added support for images, as we don't want to pollute the original component with image support.
+ *
+ * @info styling for this component is located in src/components/text.css
+ *
+ * @info
+ * This component handles basic spacing (presuming gap-8 / 32px.) You may override this by passing a gap-* class to the component.
+ *
+ * @info GHFM doesn't support different alignment of text. This needs to be passed to the component with a text-* class.
+ *
+ * @info
+ * Github-Flavored Markdown can render a variety of HTML tags. The following tags are currently supported in this component:
+ * Paragraphs: <p>
+ * Emphasis: <em>, <strong>
+ * Lists: <ul>, <ol>, <li>
+ * Links: <a>
+ * Blockquotes: <blockquote>
+ * Headings: <h1>, <h2>, <h3>
+ * Strikethrough: <del>
+ * Images: <img>
+ *
+ */
+const TextImage: React.FC<TextImage> = ({ markdown, className }) => {
+  return (
+    <div className={`markdown-text markdown-text-image ${className || ""}`}>
+      <Markdown
+        allowedElements={[
+          "a",
+          "b",
+          "blockquote",
+          "em",
+          "h1",
+          "h2",
+          "h3",
+          "hr",
+          "i",
+          "li",
+          "ol",
+          "p",
+          "pre",
+          "strong",
+          "ul",
+          "del",
+          "img",
+        ]}
+        remarkPlugins={[remarkGfm]}
+      >
+        {markdown}
+      </Markdown>
+    </div>
+  )
+}
+
+export default TextImage


### PR DESCRIPTION
<img width="1677" alt="Screenshot 2025-02-17 at 09 39 23" src="https://github.com/user-attachments/assets/d5f8291f-c4b3-4d82-8a13-bdce7449fff3" />

@info the little whitespace is added through an additional <enter> character, which will make a separate paragraph above and below the image.