### PR TITLE
AW-192 links in events cards werken niet

### DIFF
--- a/nextjs/src/app/[locale]/events/page.tsx
+++ b/nextjs/src/app/[locale]/events/page.tsx
@@ -67,6 +67,7 @@ export default async function EventsOverviewPage({
                 description={event.date_event}
                 imageUrl={event.hero?.background_image.url}
                 logoUrl={event.card_image?.url}
+                href={`/${locale}/events/${event.slug}`}
               />
             ))}
           </CardGroup>


### PR DESCRIPTION
Event pages share the same path/slug on all locales