### PR TITLE
fix (AW-309): return 404 when locale was not found

### DIFF
--- a/nextjs/src/lib/strapi.ts
+++ b/nextjs/src/lib/strapi.ts
@@ -11,7 +11,7 @@ export function normalizeLocale(locale: string) {
 
 function validateLocale(locale: Locale) {
   if (!locales.includes(locale)) {
-    throw new Error("Invalid locale")
+    return notFound()
   }
 }
 


### PR DESCRIPTION
Serve 404 when locale was not found or is invalid