### PR TITLE
Release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ straightforward as possible.
 - [PROJECTNAME-YYYY](http://tickets.projectname.com/browse/PROJECTNAME-YYYY)
   PATCH Ticket title goes here.
 
+## [1.10.0] - 2025-10-08
+
+- AW-335 feat: add toggle for event details (#288)
+- AW-324 feat: Add line break support for text-image rendered markdown (#286)
+- AW-326 feat: Change translation to Event date (#287)
+- fix AW-285: always use default port 80
+
 ## [1.9.0] - 2025-09-23
 
 - refactor (AW-319): remove matomo middleware

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@headlessui/react": "^2.1.5",
         "@smakss/react-scroll-direction": "^4.2.0",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/nextjs/src/app/[locale]/(news)/news-detail.tsx
+++ b/nextjs/src/app/[locale]/(news)/news-detail.tsx
@@ -9,6 +9,7 @@ import { LinkedLocale } from "@/components/nav-bar/linked-locales-provider"
 import { getNewsPage } from "@/lib/strapi"
 import { Locale, getLocaleDateFormatted } from "@/lib/locale"
 import { NEWS_SLUGS } from "@/lib/slugs"
+import { getDictionary } from "@/lib/get-dictionary.server"
 
 export default async function NewsDetail({
   activeLocale,
@@ -36,6 +37,7 @@ export default async function NewsDetail({
     },
   )
   locales.push(activeLocale)
+  const dictionary = await getDictionary(activeLocale.locale as Locale)
 
   return (
     <>
@@ -47,7 +49,7 @@ export default async function NewsDetail({
         <div className="container sm:px-2">
           <div className="mx-auto pb-8 max-w-4xl">
             <InfoLabel
-              text={`Published at ${getLocaleDateFormatted({ date: publication_date ?? publishedAt ?? createdAt, locale: activeLocale.locale as Locale })}`}
+              text={`${dictionary.common.publishedAt} ${getLocaleDateFormatted({ date: publication_date ?? publishedAt ?? createdAt, locale: activeLocale.locale as Locale })}`}
               className="block mb-4"
             />
             <TextImage markdown={main_blog} />

--- a/nextjs/src/app/[locale]/blogs/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/blogs/[slug]/page.tsx
@@ -9,6 +9,7 @@ import InfoLabel from "@/components/info-label"
 import TextImage from "@/components/text-image"
 import { renderSections } from "@/components/dynamic-zone/render-sections"
 import Footer from "@/components/stapi/footer"
+import { getDictionary } from "@/lib/get-dictionary.server"
 
 export async function generateMetadata({
   params: { locale, slug },
@@ -48,6 +49,7 @@ export default async function BlogPage({
     },
   )
   locales.push(activeLocale)
+  const dictionary = await getDictionary(activeLocale.locale as Locale)
 
   return (
     <>
@@ -59,7 +61,7 @@ export default async function BlogPage({
         <div className="container sm:px-2">
           <div className="mx-auto pb-8 max-w-4xl">
             <InfoLabel
-              text={`Published at ${getLocaleDateFormatted({ date: publishedAt ?? createdAt, locale: activeLocale.locale as Locale })}`}
+              text={`${dictionary.common.publishedAt} ${getLocaleDateFormatted({ date: publishedAt ?? createdAt, locale: activeLocale.locale as Locale })}`}
               className="block mb-4"
             />
             <TextImage markdown={main_blog} />

--- a/nextjs/src/app/[locale]/events/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/events/[slug]/page.tsx
@@ -83,6 +83,7 @@ export default async function EventsDetailPage({
     map_embed_html,
     sign_up_button,
     is_past_event,
+    show_event_details_section,
     sections,
   } = data
 
@@ -121,19 +122,21 @@ export default async function EventsDetailPage({
           )}
         </div>
       </Container>
-      <Container
-        padding="both-padding"
-        background={is_past_event ? "sapphire" : "stone"}
-      >
-        <SectionEvent
-          title={dictionary.pages.events.title}
-          date={date_event}
-          location={address}
-          time={time}
-          html={map_embed_html}
-          cta={is_past_event === true ? undefined : sign_up_button}
-        />
-      </Container>
+      {show_event_details_section !== false && (
+        <Container
+          padding="both-padding"
+          background={is_past_event ? "sapphire" : "stone"}
+        >
+          <SectionEvent
+            title={dictionary.pages.events.title}
+            date={date_event}
+            location={address}
+            time={time}
+            html={map_embed_html}
+            cta={is_past_event === true ? undefined : sign_up_button}
+          />
+        </Container>
+      )}
       {sections &&
         sections.length > 0 &&
         sections.map((section: any, index: number) =>

--- a/nextjs/src/components/text-image.tsx
+++ b/nextjs/src/components/text-image.tsx
@@ -38,6 +38,7 @@ const TextImage: React.FC<TextImage> = ({ markdown, className }) => {
           "a",
           "b",
           "blockquote",
+          "br",
           "em",
           "h1",
           "h2",

--- a/nextjs/src/dictionaries/de-ch.json
+++ b/nextjs/src/dictionaries/de-ch.json
@@ -42,6 +42,7 @@
         }
     },
     "common": {
-        "of": "von"
+        "of": "von",
+        "publishedAt": "Veröffentlicht am"
     }
 }

--- a/nextjs/src/dictionaries/de-de.json
+++ b/nextjs/src/dictionaries/de-de.json
@@ -42,6 +42,7 @@
         }
     },
     "common": {
-        "of": "von"
+        "of": "von",
+        "publishedAt": "Veröffentlicht am"
     }
 }

--- a/nextjs/src/dictionaries/en-au.json
+++ b/nextjs/src/dictionaries/en-au.json
@@ -33,7 +33,7 @@
         "events": {
             "title": "Event Details",
             "cta": "Sign up now",
-            "dateEvent": "Date event"
+            "dateEvent": "Event date"
         },
         "notFound": {
             "body": "## 404\nSpace invaders destroyed this page! Take revenge on them!\nUse `space` to shoot and `←` and `→` to move!",
@@ -42,6 +42,7 @@
         }
     },
     "common": {
-        "of": "of"
+        "of": "of",
+        "publishedAt": "Published at"
     }
 }

--- a/nextjs/src/dictionaries/en.json
+++ b/nextjs/src/dictionaries/en.json
@@ -33,7 +33,7 @@
         "events": {
             "title": "Event Details",
             "cta": "Sign up now",
-            "dateEvent": "Date event"
+            "dateEvent": "Event date"
         },
         "notFound": {
             "body": "## 404\nSpace invaders destroyed this page! Take revenge on them!\nUse `space` to shoot and `←` and `→` to move!",
@@ -42,6 +42,7 @@
         }
     },
     "common": {
-        "of": "of"
+        "of": "of",
+        "publishedAt": "Published at"
     }
 }

--- a/nextjs/src/dictionaries/nl.json
+++ b/nextjs/src/dictionaries/nl.json
@@ -42,6 +42,7 @@
         }
     },
     "common": {
-        "of": "van"
+        "of": "van",
+        "publishedAt": "Gepubliceerd op"
     }
 }

--- a/strapi/package-lock.json
+++ b/strapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@strapi/plugin-cloud": "5.8.1",
         "@strapi/plugin-users-permissions": "5.8.1",

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "description": "A Strapi application",
   "scripts": {

--- a/strapi/src/api/event-page/content-types/event-page/schema.json
+++ b/strapi/src/api/event-page/content-types/event-page/schema.json
@@ -171,6 +171,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "show_event_details_section": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "boolean",
+      "default": true,
+      "required": true
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1039,6 +1039,14 @@ export interface ApiEventPageEventPage extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    show_event_details_section: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }> &
+      Schema.Attribute.DefaultTo<true>;
     sign_up_button: Schema.Attribute.Component<
       'external-links.call-to-action',
       false


### PR DESCRIPTION
## [1.10.0] - 2025-10-08

- AW-335 feat: add toggle for event details (#288)
- AW-324 feat: Add line break support for text-image rendered markdown (#286)
- AW-326 feat: Change translation to Event date (#287)
- fix AW-285: always use default port 80