### PR TITLE
AW-364 option for multiple dates for events

### DIFF
--- a/nextjs/src/app/[locale]/events/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/events/[slug]/page.tsx
@@ -10,7 +10,7 @@ import SectionEvent from "@/components/sections/section-event"
 import { renderSections } from "@/components/dynamic-zone/render-sections"
 import Footer from "@/components/stapi/footer"
 import { getDictionary } from "@/lib/get-dictionary.server"
-import { Locale, getLocaleDateFormatted } from "@/lib/locale"
+import { Locale, getLocaleDateRangeFormatted } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
 
@@ -78,6 +78,7 @@ export default async function EventsDetailPage({
     hero,
     details,
     date_event,
+    date_event_end,
     time,
     address,
     map_embed_html,
@@ -93,8 +94,9 @@ export default async function EventsDetailPage({
     sign_up_button.text = sign_up_button?.label
   }
 
-  const formattedDate = getLocaleDateFormatted({
-    date: date_event,
+  const formattedDate = getLocaleDateRangeFormatted({
+    startDate: date_event,
+    endDate: date_event_end,
     locale: activeLocale.locale as Locale,
   })
 
@@ -134,7 +136,7 @@ export default async function EventsDetailPage({
         >
           <SectionEvent
             title={dictionary.pages.events.title}
-            date={date_event}
+            date={formattedDate}
             location={address}
             time={time}
             html={map_embed_html}

--- a/nextjs/src/app/[locale]/events/page.tsx
+++ b/nextjs/src/app/[locale]/events/page.tsx
@@ -9,7 +9,7 @@ import Footer from "@/components/stapi/footer"
 import CardGroup from "@/components/cards/card-group"
 import Container from "@/components/container"
 import CardArticle from "@/components/cards/card-article"
-import { getLocaleDateFormatted, Locale } from "@/lib/locale"
+import { getLocaleDateRangeFormatted, Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
 
@@ -72,8 +72,12 @@ export default async function EventsOverviewPage({
   const { hero, intro, sections } = data
   const cards = await getEventPageCards(locale)
 
-  function formatDate(date: string) {
-    return getLocaleDateFormatted({ date, locale: locale as Locale })
+  function formatDate(startDate: string, endDate?: string | null) {
+    return getLocaleDateRangeFormatted({
+      startDate,
+      endDate,
+      locale: locale as Locale,
+    })
   }
 
   return (
@@ -99,7 +103,7 @@ export default async function EventsOverviewPage({
                 key={event.documentId.slice(-4)}
                 title={event.metadata_title}
                 subtitle={event.address}
-                description={`${formatDate(event.date_event)}`}
+                description={formatDate(event.date_event, event.date_event_end)}
                 imageUrl={event.hero?.background_image.url}
                 logoUrl={event.card_image?.url}
                 href={`/${locale.toLocaleLowerCase()}/events/${event.slug}`}

--- a/nextjs/src/lib/locale.ts
+++ b/nextjs/src/lib/locale.ts
@@ -2,6 +2,12 @@ export const locales = ["en", "en-au", "nl", "de-ch", "de-de"] as const
 
 export type Locale = (typeof locales)[number]
 
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "long",
+  day: "2-digit",
+}
+
 export function getLocaleDateFormatted({
   date,
   locale,
@@ -10,10 +16,25 @@ export function getLocaleDateFormatted({
   locale: Locale
 }) {
   const dateObj = new Date(date)
-  const options: Intl.DateTimeFormatOptions = {
-    year: "numeric",
-    month: "long",
-    day: "2-digit",
+  return dateObj.toLocaleDateString(locale, DATE_FORMAT_OPTIONS)
+}
+
+export function getLocaleDateRangeFormatted({
+  startDate,
+  endDate,
+  locale,
+}: {
+  startDate: string
+  endDate?: string | null
+  locale: Locale
+}) {
+  const start = new Date(startDate)
+  if (!endDate || endDate === startDate) {
+    return start.toLocaleDateString(locale, DATE_FORMAT_OPTIONS)
   }
-  return dateObj.toLocaleDateString(locale, options)
+  const end = new Date(endDate)
+  return new Intl.DateTimeFormat(locale, DATE_FORMAT_OPTIONS).formatRange(
+    start,
+    end,
+  )
 }

--- a/strapi/src/api/event-page/content-types/event-page/schema.json
+++ b/strapi/src/api/event-page/content-types/event-page/schema.json
@@ -69,6 +69,15 @@
       "type": "date",
       "required": true
     },
+    "date_event_end": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "date",
+      "required": false
+    },
     "time": {
       "pluginOptions": {
         "i18n": {

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -954,6 +954,12 @@ export interface ApiEventPageEventPage extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    date_event_end: Schema.Attribute.Date &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     details: Schema.Attribute.RichText &
       Schema.Attribute.SetPluginOptions<{
         i18n: {


### PR DESCRIPTION
## Summary
  - Add optional `date_event_end` field to the event-page Strapi schema
  - New `getLocaleDateRangeFormatted` helper uses `Intl.DateTimeFormat#formatRange` for locale-aware ranges (e.g. "17 - 19 May 2026"); collapses to a single date when no end is set
  - Events overview cards and the event detail page (both the `InfoLabel` and the lower `SectionEvent`) now render the range; also fixes the detail page's lower section, which previously displayed the raw ISO date