### PR TITLE
AW-329 opengraph

### DIFF
--- a/nextjs/src/app/(homepage)/de-ch/page.tsx
+++ b/nextjs/src/app/(homepage)/de-ch/page.tsx
@@ -3,26 +3,24 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const locale = "de-ch" as Locale
   const data = await getHomepage(locale)
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 export default function Home() {
   const locale = "de-ch" as Locale

--- a/nextjs/src/app/(homepage)/de-de/page.tsx
+++ b/nextjs/src/app/(homepage)/de-de/page.tsx
@@ -4,26 +4,24 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const locale = "de-de" as Locale
   const data = await getHomepage(locale)
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 export default function Home() {
   const locale = "de-de" as Locale

--- a/nextjs/src/app/(homepage)/en-au/page.tsx
+++ b/nextjs/src/app/(homepage)/en-au/page.tsx
@@ -4,26 +4,24 @@ import CookieNotice from "@/components/cookie-notice"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const locale = "en-au" as Locale
   const data = await getHomepage(locale)
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 export default function Home() {
   const locale = "en-au" as Locale

--- a/nextjs/src/app/(homepage)/en/page.tsx
+++ b/nextjs/src/app/(homepage)/en/page.tsx
@@ -4,26 +4,24 @@ import CookieNotice from "@/components/cookie-notice"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const locale = "en" as Locale
   const data = await getHomepage(locale)
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 export default function Home() {
   const locale = "en" as Locale

--- a/nextjs/src/app/(homepage)/nl/page.tsx
+++ b/nextjs/src/app/(homepage)/nl/page.tsx
@@ -4,26 +4,24 @@ import CookieNotice from "@/components/cookie-notice"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const locale = "nl" as Locale
   const data = await getHomepage(locale)
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 export default function Home() {
   const locale = "nl" as Locale

--- a/nextjs/src/app/[...slug]/page.tsx
+++ b/nextjs/src/app/[...slug]/page.tsx
@@ -9,6 +9,7 @@ import Footer from "@/components/stapi/footer"
 import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export async function generateMetadata({
   params: { slug },
@@ -33,14 +34,7 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${path}`,
-      languages,
-    },
-  }
+  return buildMetadata({ data, locale, path, languages })
 }
 
 export default async function LandingPage({

--- a/nextjs/src/app/[locale]/(case-studies)/case-studies/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/case-studies/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getCaseStudy } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${CASE_STUDIES_SLUGS[locale]}/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function DetailPage({

--- a/nextjs/src/app/[locale]/(case-studies)/case-studies/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/case-studies/page.tsx
@@ -4,6 +4,7 @@ import { CASE_STUDIES_SLUGS } from "@/lib/slugs"
 import { Metadata } from "next"
 import { getCaseStudiesOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO refactor
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: CASE_STUDIES_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function OverviewPage({

--- a/nextjs/src/app/[locale]/(case-studies)/casestudies/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/casestudies/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getCaseStudy } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${CASE_STUDIES_SLUGS[locale]}/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function DetailPage({

--- a/nextjs/src/app/[locale]/(case-studies)/casestudies/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/casestudies/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getCaseStudiesOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO refactor
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: CASE_STUDIES_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function OverviewPage({

--- a/nextjs/src/app/[locale]/(case-studies)/referenzen/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/referenzen/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getCaseStudy } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${CASE_STUDIES_SLUGS[locale]}/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function DetailPage({

--- a/nextjs/src/app/[locale]/(case-studies)/referenzen/page.tsx
+++ b/nextjs/src/app/[locale]/(case-studies)/referenzen/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getCaseStudiesOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO refactor
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${CASE_STUDIES_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: CASE_STUDIES_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function OverviewPage({

--- a/nextjs/src/app/[locale]/(news)/news/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(news)/news/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getNewsPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${NEWS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${NEWS_SLUGS[locale]}/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function NewsDetailPage({

--- a/nextjs/src/app/[locale]/(news)/news/page.tsx
+++ b/nextjs/src/app/[locale]/(news)/news/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getNewsOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${NEWS_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: NEWS_SLUGS[locale],
+    languages,
+  })
 }
 
 export default async function NewsOverviewPage({

--- a/nextjs/src/app/[locale]/(news)/nieuws/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(news)/nieuws/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getNewsPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${NEWS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${NEWS_SLUGS[locale]}/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function NewsDetailPage({

--- a/nextjs/src/app/[locale]/(news)/nieuws/page.tsx
+++ b/nextjs/src/app/[locale]/(news)/nieuws/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getNewsOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${NEWS_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: NEWS_SLUGS[locale],
+    languages,
+  })
 }
 
 export default async function NewsOverviewPage({

--- a/nextjs/src/app/[locale]/(pages)/[...slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(pages)/[...slug]/page.tsx
@@ -9,6 +9,7 @@ import Footer from "@/components/stapi/footer"
 import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export async function generateMetadata({
   params: { locale, slug },
@@ -33,14 +34,7 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${path}`,
-      languages,
-    },
-  }
+  return buildMetadata({ data, locale, path, languages })
 }
 
 export default async function LandingPage({

--- a/nextjs/src/app/[locale]/(partners-products)/partner-und-produkte/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partner-und-produkte/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getPartnerAndProductsPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function PartnerAndProductsPage({

--- a/nextjs/src/app/[locale]/(partners-products)/partners-and-products/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partners-and-products/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getPartnerAndProductsPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function PartnerAndProductsPage({

--- a/nextjs/src/app/[locale]/(partners-products)/partners-en-producten/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(partners-products)/partners-en-producten/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getPartnerAndProductsPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${PARTNER_PRODUCTS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function PartnerAndProductsPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/loesungen/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/loesungen/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getSolutionPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${SOLUTIONS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function SolutionsDetailPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/loesungen/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/loesungen/page.tsx
@@ -4,6 +4,7 @@ import { SOLUTIONS_SLUGS } from "@/lib/slugs"
 import { Metadata } from "next"
 import { getSolutionsOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: SOLUTIONS_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function SolutionsPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/oplossingen/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/oplossingen/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getSolutionPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${SOLUTIONS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function SolutionsDetailPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/oplossingen/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/oplossingen/page.tsx
@@ -4,6 +4,7 @@ import { SOLUTIONS_SLUGS } from "@/lib/slugs"
 import { Metadata } from "next"
 import { getSolutionsOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: SOLUTIONS_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function SolutionsPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/solutions/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/solutions/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getSolutionPage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${SOLUTIONS_SLUGS[locale]}/${slug}`,
+    languages,
+  })
 }
 
 export default async function SolutionsDetailPage({

--- a/nextjs/src/app/[locale]/(solutions-group)/solutions/page.tsx
+++ b/nextjs/src/app/[locale]/(solutions-group)/solutions/page.tsx
@@ -4,6 +4,7 @@ import { SOLUTIONS_SLUGS } from "@/lib/slugs"
 import { Metadata } from "next"
 import { getSolutionsOverview } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 import { notFound } from "next/navigation"
 
 export async function generateMetadata({
@@ -33,14 +34,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/${SOLUTIONS_SLUGS[locale]}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: SOLUTIONS_SLUGS[locale],
+    languages,
+  })
 }
 
 export default function SolutionsPage({

--- a/nextjs/src/app/[locale]/blogs/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/blogs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getLocaleDateFormatted, Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { getBlogPage } from "@/lib/strapi"
 import { BLOG_SLUGS } from "@/lib/slugs"
+import { buildMetadata } from "@/lib/metadata"
 import { NavProvider } from "@/components/nav-bar/nav-context"
 import NavBar from "@/components/nav-bar/nav-bar"
 import HeroWrapper from "@/components/stapi/hero-wrapper"
@@ -21,10 +22,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const data = await getBlogPage(locale, slug)
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `${BLOG_SLUGS[locale]}/${slug}`,
+    type: "article",
+  })
 }
 
 export default async function BlogPage({

--- a/nextjs/src/app/[locale]/blogs/page.tsx
+++ b/nextjs/src/app/[locale]/blogs/page.tsx
@@ -1,5 +1,6 @@
 import { getBlogOverviewCards, getBlogsOverview } from "@/lib/strapi"
 import { getLocaleDateFormatted, Locale } from "@/lib/locale"
+import { buildMetadata } from "@/lib/metadata"
 import { NavProvider } from "@/components/nav-bar/nav-context"
 import NavBar from "@/components/nav-bar/nav-bar"
 import HeroWrapper from "@/components/stapi/hero-wrapper"
@@ -19,10 +20,11 @@ export async function generateMetadata({
   }
 }) {
   const data = await getBlogsOverview(locale)
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: "blogs",
+  })
 }
 
 export default async function Page({

--- a/nextjs/src/app/[locale]/events/[slug]/page.tsx
+++ b/nextjs/src/app/[locale]/events/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { getDictionary } from "@/lib/get-dictionary.server"
 import { Locale, getLocaleDateFormatted } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export async function generateMetadata({
   params: { locale, slug },
@@ -36,14 +37,13 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.metadata_description,
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/events/${slug}`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: `events/${slug}`,
+    type: "article",
+    languages,
+  })
 }
 
 export default async function EventsDetailPage({

--- a/nextjs/src/app/[locale]/events/page.tsx
+++ b/nextjs/src/app/[locale]/events/page.tsx
@@ -12,6 +12,7 @@ import CardArticle from "@/components/cards/card-article"
 import { getLocaleDateFormatted, Locale } from "@/lib/locale"
 import { Metadata } from "next"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export async function generateMetadata({
   params: { locale },
@@ -35,14 +36,12 @@ export async function generateMetadata({
     languages["x-default"] = languages.en
   }
 
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO refactor
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/${locale}/events`,
-      languages,
-    },
-  }
+  return buildMetadata({
+    data,
+    locale,
+    path: "events",
+    languages,
+  })
 }
 
 export default async function EventsOverviewPage({

--- a/nextjs/src/app/layout.tsx
+++ b/nextjs/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Source_Sans_3 } from "next/font/google"
 import "./globals.css"
 import dynamic from "next/dynamic"
 import { Matomo } from "@/components/matomo/matomo"
+import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { DEFAULT_SHARE_IMAGE, SITE_NAME } from "@/lib/metadata"
 
 const CookieNotice = dynamic(() => import("@/components/cookie-notice"), {
   ssr: false,
@@ -14,10 +16,26 @@ const sourceSans3 = Source_Sans_3({
   variable: "--font-source-sans-3",
 })
 
+const DEFAULT_DESCRIPTION =
+  "Plan innovatively. Build sustainably. Run resiliently. As open source professionals, we offer a wide range of services and solutions from a single source. Open technologies and standards are our key to innovation. Potential. Unlocked."
+
 export const metadata: Metadata = {
-  title: "Adfinis",
-  description:
-    "Plan innovatively. Build sustainably. Run resiliently. As open source professionals, we offer a wide range of services and solutions from a single source. Open technologies and standards are our key to innovation. Potential. Unlocked.",
+  metadataBase: ABSOLUTE_URL ? new URL(ABSOLUTE_URL) : undefined,
+  title: SITE_NAME,
+  description: DEFAULT_DESCRIPTION,
+  openGraph: {
+    siteName: SITE_NAME,
+    type: "website",
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [{ url: DEFAULT_SHARE_IMAGE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [DEFAULT_SHARE_IMAGE],
+  },
   icons: {
     icon: [
       { url: "/favicon-16x16.png", sizes: "16x16", type: "image/png" },

--- a/nextjs/src/app/page.tsx
+++ b/nextjs/src/app/page.tsx
@@ -4,25 +4,24 @@ import CookieNotice from "@/components/cookie-notice"
 import { Metadata } from "next"
 import { getHomepage } from "@/lib/strapi"
 import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { buildMetadata } from "@/lib/metadata"
 
 export const dynamic = "force-dynamic"
 export async function generateMetadata(): Promise<Metadata> {
   const data = await getHomepage("en")
-  return {
-    title: data.metadata_title,
-    description: data.meta_description, // TODO change to metadata
-    alternates: {
-      canonical: `${ABSOLUTE_URL}/`,
-      languages: {
-        en: `${ABSOLUTE_URL}/en`,
-        "en-AU": `${ABSOLUTE_URL}/en-au`,
-        "de-DE": `${ABSOLUTE_URL}/de-de`,
-        "de-CH": `${ABSOLUTE_URL}/de-ch`,
-        nl: `${ABSOLUTE_URL}/nl`,
-        "x-default": `${ABSOLUTE_URL}/`,
-      },
+  return buildMetadata({
+    data,
+    locale: "en",
+    url: `${ABSOLUTE_URL}/`,
+    languages: {
+      en: `${ABSOLUTE_URL}/en`,
+      "en-AU": `${ABSOLUTE_URL}/en-au`,
+      "de-DE": `${ABSOLUTE_URL}/de-de`,
+      "de-CH": `${ABSOLUTE_URL}/de-ch`,
+      nl: `${ABSOLUTE_URL}/nl`,
+      "x-default": `${ABSOLUTE_URL}/`,
     },
-  }
+  })
 }
 
 export default async function Page() {

--- a/nextjs/src/lib/metadata.ts
+++ b/nextjs/src/lib/metadata.ts
@@ -1,0 +1,105 @@
+import type { Metadata } from "next"
+import { ABSOLUTE_URL } from "@/lib/absolute-url"
+import { Locale } from "@/lib/locale"
+
+export const SITE_NAME = "Adfinis"
+
+export const DEFAULT_SHARE_IMAGE =
+  "https://adfinis-assets.ams3.cdn.digitaloceanspaces.com/public-assets/Adfinis_Blue_3_41b329491f_25f3a40e9e.png"
+
+const OG_LOCALE: Record<Locale, string> = {
+  en: "en_US",
+  "en-au": "en_AU",
+  "de-ch": "de_CH",
+  "de-de": "de_DE",
+  nl: "nl_NL",
+}
+
+type StrapiMedia = {
+  url: string
+  width?: number | null
+  height?: number | null
+  alternativeText?: string | null
+}
+
+export type Seo = {
+  share_image?: StrapiMedia | null
+  og_title?: string | null
+  og_description?: string | null
+} | null
+
+type StrapiMetadataInput = {
+  metadata_title?: string
+  metadata_description?: string
+  meta_description?: string
+  seo?: Seo
+}
+
+type BuildMetadataArgs = {
+  data: StrapiMetadataInput
+  locale: Locale
+  path?: string
+  type?: "website" | "article"
+  languages?: Record<string, string>
+  url?: string
+}
+
+export function buildMetadata({
+  data,
+  locale,
+  path = "",
+  type = "website",
+  languages,
+  url: urlOverride,
+}: BuildMetadataArgs): Metadata {
+  const seo = data.seo ?? undefined
+  const title = seo?.og_title || data.metadata_title || SITE_NAME
+  const description =
+    seo?.og_description ||
+    data.metadata_description ||
+    data.meta_description ||
+    ""
+
+  const cleanPath = path.replace(/^\/+|\/+$/g, "")
+  const url =
+    urlOverride ??
+    (cleanPath
+      ? `${ABSOLUTE_URL}/${locale}/${cleanPath}`
+      : `${ABSOLUTE_URL}/${locale}`)
+
+  const shareImage = seo?.share_image
+  const ogImage = shareImage?.url
+    ? {
+        url: shareImage.url,
+        ...(shareImage.width ? { width: shareImage.width } : {}),
+        ...(shareImage.height ? { height: shareImage.height } : {}),
+        ...(shareImage.alternativeText
+          ? { alt: shareImage.alternativeText }
+          : {}),
+      }
+    : { url: DEFAULT_SHARE_IMAGE }
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      ...(languages ? { languages } : {}),
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type,
+      locale: OG_LOCALE[locale],
+      images: [ogImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage.url],
+    },
+  }
+}

--- a/nextjs/src/lib/strapi.ts
+++ b/nextjs/src/lib/strapi.ts
@@ -140,7 +140,7 @@ export function getEventsOverview(locale: Locale) {
 export function getBlogsOverview(locale: Locale) {
   validateLocale(locale)
   return strapi(
-    `blogs-overview?locale=${normalizeLocale(locale)}&status=published`,
+    `blogs-overview?locale=${normalizeLocale(locale)}&populate[seo][populate]=*&status=published`,
   )
 }
 

--- a/strapi/src/api/case-studies-overview/content-types/case-studies-overview/schema.json
+++ b/strapi/src/api/case-studies-overview/content-types/case-studies-overview/schema.json
@@ -83,6 +83,16 @@
         "sections.video-with-text-section"
       ],
       "required": false
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/event-page/content-types/event-page/schema.json
+++ b/strapi/src/api/event-page/content-types/event-page/schema.json
@@ -181,6 +181,16 @@
       "type": "boolean",
       "default": true,
       "required": true
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/event-page/middlewares/event-details.ts
+++ b/strapi/src/api/event-page/middlewares/event-details.ts
@@ -7,6 +7,9 @@ module.exports = (config, { strapi }) => {
       ...ctx.query,
       populate: {
         localizations: true,
+        seo: {
+          populate: '*'
+        },
         hero: {
           populate: '*'
         },

--- a/strapi/src/api/events-overview/content-types/events-overview/schema.json
+++ b/strapi/src/api/events-overview/content-types/events-overview/schema.json
@@ -82,6 +82,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/homepage/content-types/homepage/schema.json
+++ b/strapi/src/api/homepage/content-types/homepage/schema.json
@@ -82,6 +82,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/news-overview/content-types/news-overview/schema.json
+++ b/strapi/src/api/news-overview/content-types/news-overview/schema.json
@@ -82,6 +82,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/news-page/content-types/news-page/schema.json
+++ b/strapi/src/api/news-page/content-types/news-page/schema.json
@@ -144,6 +144,16 @@
         }
       },
       "type": "datetime"
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/page-case-study/content-types/page-case-study/schema.json
+++ b/strapi/src/api/page-case-study/content-types/page-case-study/schema.json
@@ -141,6 +141,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/page-partner-and-product/content-types/page-partner-and-product/schema.json
+++ b/strapi/src/api/page-partner-and-product/content-types/page-partner-and-product/schema.json
@@ -102,6 +102,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -101,6 +101,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/solutions-overview/content-types/solutions-overview/schema.json
+++ b/strapi/src/api/solutions-overview/content-types/solutions-overview/schema.json
@@ -82,6 +82,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/api/solutions-page/content-types/solutions-page/schema.json
+++ b/strapi/src/api/solutions-page/content-types/solutions-page/schema.json
@@ -102,6 +102,16 @@
         "sections.video-section",
         "sections.video-with-text-section"
       ]
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "global.seo"
     }
   }
 }

--- a/strapi/src/components/global/seo.json
+++ b/strapi/src/components/global/seo.json
@@ -1,0 +1,26 @@
+{
+  "collectionName": "components_global_seos",
+  "info": {
+    "displayName": "SEO / Share",
+    "description": "Customise how a page appears when shared (Open Graph / social link preview)."
+  },
+  "options": {},
+  "attributes": {
+    "share_image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "og_title": {
+      "type": "string",
+      "required": false
+    },
+    "og_description": {
+      "type": "text",
+      "required": false
+    }
+  }
+}

--- a/strapi/src/middlewares/populate-sections-with-intro-and-localizations.ts
+++ b/strapi/src/middlewares/populate-sections-with-intro-and-localizations.ts
@@ -6,6 +6,9 @@ module.exports = (config, { strapi }) => {
       ...ctx.query,
       populate: {
         localizations: true,
+        seo: {
+          populate: "*",
+        },
         hero: {
           populate: "*",
         },

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -388,6 +388,19 @@ export interface GlobalIntroBody extends Struct.ComponentSchema {
   };
 }
 
+export interface GlobalSeo extends Struct.ComponentSchema {
+  collectionName: 'components_global_seos';
+  info: {
+    description: 'Customise how a page appears when shared (Open Graph / social link preview).';
+    displayName: 'SEO / Share';
+  };
+  attributes: {
+    og_description: Schema.Attribute.Text;
+    og_title: Schema.Attribute.String;
+    share_image: Schema.Attribute.Media<'images'>;
+  };
+}
+
 export interface GlobalSlaItem extends Struct.ComponentSchema {
   collectionName: 'components_global_sla_items';
   info: {
@@ -1093,6 +1106,7 @@ declare module '@strapi/strapi' {
       'global.hero-with-cta': GlobalHeroWithCta;
       'global.intro': GlobalIntro;
       'global.intro-body': GlobalIntroBody;
+      'global.seo': GlobalSeo;
       'global.sla-item': GlobalSlaItem;
       'menu.menu-link': MenuMenuLink;
       'menu.menu-section': MenuMenuSection;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -744,6 +744,12 @@ export interface ApiCaseStudiesOverviewCaseStudiesOverview
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1039,6 +1045,12 @@ export interface ApiEventPageEventPage extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     show_event_details_section: Schema.Attribute.Boolean &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -1154,6 +1166,12 @@ export interface ApiEventsOverviewEventsOverview
         'sections.video-with-text-section',
       ]
     > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
@@ -1469,6 +1487,12 @@ export interface ApiHomepageHomepage extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1699,6 +1723,12 @@ export interface ApiNewsOverviewNewsOverview extends Struct.SingleTypeSchema {
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1820,6 +1850,12 @@ export interface ApiNewsPageNewsPage extends Struct.CollectionTypeSchema {
         'sections.video-with-text-section',
       ]
     > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
@@ -1955,6 +1991,12 @@ export interface ApiPageCaseStudyPageCaseStudy
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     slug: Schema.Attribute.UID<'metadata_title'> &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -2059,6 +2101,12 @@ export interface ApiPagePartnerAndProductPagePartnerAndProduct
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     slug: Schema.Attribute.UID<'metadata_title'> &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -2153,6 +2201,12 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         'sections.video-with-text-section',
       ]
     > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
@@ -2363,6 +2417,12 @@ export interface ApiSolutionsOverviewSolutionsOverview
           localized: true;
         };
       }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -2455,6 +2515,12 @@ export interface ApiSolutionsPageSolutionsPage
         'sections.video-with-text-section',
       ]
     > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    seo: Schema.Attribute.Component<'global.seo', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
# Add Open Graph share image customisation via Strapi

Adds a new optional, localized `seo` component in Strapi (`share_image` + optional `og_title` / `og_description` overrides) attached to the page content types that carry SEO metadata. Editors can now control the social link preview from strapi.

On the Next.js side, introduces a `buildMetadata` helper (`lib/metadata.ts`) that emits the full `openGraph` + `twitter` (`summary_large_image`) tags alongside the existing title/description/canonical/hreflang. All `generateMetadata` callsites and the root `layout.tsx` defaults route through it, with a fallback to the Adfinis logo when no `share_image` is uploaded.

## Test plan
- [ ] Restart Strapi so the new component/fields migrate.
- [ ] Upload a `share_image` on a page and check the preview with opengraph.xyz / LinkedIn Post Inspector / a Slack unfurl.
- [ ] Confirm pages without a `share_image` fall back to the default image and that `og:title` / `og:description` overrides take precedence when set.