### PR TITLE
AW-328 urls without markdown markup resolve to http

### DIFF
--- a/nextjs/src/components/markdown/url-transform.ts
+++ b/nextjs/src/components/markdown/url-transform.ts
@@ -1,0 +1,21 @@
+import { defaultUrlTransform } from "react-markdown"
+
+/**
+ * @description Shared `urlTransform` for the markdown components.
+ *
+ * - Preserves `tel:` links (react-markdown's default sanitizer would otherwise
+ *   strip them).
+ * - Upgrades `http://` to `https://`. This makes bare autolinks default to
+ *   https: remark-gfm expands a literal like `www.adfinis.com` into
+ *   `http://www.adfinis.com` per the GFM spec, and we want those served over
+ *   https.
+ */
+export const markdownUrlTransform = (url: string): string => {
+  if (url.startsWith("tel:")) {
+    return url
+  }
+
+  return defaultUrlTransform(
+    url.startsWith("http://") ? `https://${url.slice("http://".length)}` : url,
+  )
+}

--- a/nextjs/src/components/text-image.test.tsx
+++ b/nextjs/src/components/text-image.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react"
+import { expect, test } from "vitest"
+import TextImage from "./text-image"
+
+test("upgrades bare www autolinks to https instead of http", () => {
+  const { container } = render(<TextImage markdown={"www.example.com"} />)
+  const link = container.querySelector("a")
+  expect(link?.getAttribute("href")).toBe("https://www.example.com")
+})
+
+test("keeps explicit https autolinks as https", () => {
+  const { container } = render(
+    <TextImage markdown={"https://www.example.com"} />,
+  )
+  const link = container.querySelector("a")
+  expect(link?.getAttribute("href")).toBe("https://www.example.com")
+})

--- a/nextjs/src/components/text-image.tsx
+++ b/nextjs/src/components/text-image.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { allowedElements } from "./text"
 import CodeBlock from "./markdown/code-block"
+import { markdownUrlTransform } from "./markdown/url-transform"
 
 interface TextImage {
   markdown: string
@@ -39,6 +40,7 @@ const TextImage: React.FC<TextImage> = ({ markdown, className }) => {
         allowedElements={[...allowedElements, "img"]}
         remarkPlugins={[remarkGfm]}
         components={{ code: CodeBlock }}
+        urlTransform={markdownUrlTransform}
       >
         {markdown}
       </Markdown>

--- a/nextjs/src/components/text.tsx
+++ b/nextjs/src/components/text.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import Markdown, { defaultUrlTransform } from "react-markdown"
+import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import CodeBlock from "./markdown/code-block"
+import { markdownUrlTransform } from "./markdown/url-transform"
 
 interface TextProps {
   markdown: string
@@ -59,9 +60,7 @@ const Text: React.FC<TextProps> = ({ markdown, className }) => {
         allowedElements={allowedElements}
         remarkPlugins={[remarkGfm]}
         components={{ code: CodeBlock }}
-        urlTransform={(url) =>
-          url.startsWith("tel:") ? url : defaultUrlTransform(url)
-        }
+        urlTransform={markdownUrlTransform}
       >
         {markdown}
       </Markdown>


### PR DESCRIPTION
Upgrades `http://` to `https://`. 
This makes bare autolinks default to https: remark-gfm expands a literal like `www.adfinis.com` into `http://www.adfinis.com` per the GFM spec, and we want those served over https